### PR TITLE
Rename addr to address in Android

### DIFF
--- a/mdns_plugin/android/src/main/kotlin/com/mutablelogic/mdns_plugin/MDNSPlugin.kt
+++ b/mdns_plugin/android/src/main/kotlin/com/mutablelogic/mdns_plugin/MDNSPlugin.kt
@@ -41,7 +41,7 @@ class MDNSPlugin : MethodCallHandler,StreamHandler {
 
         val addr = serviceInfo.getHost()?.getHostAddress()
         addr?.let {
-          map["addr"] = listOf(addr,serviceInfo.getPort())
+          map["address"] = listOf(listOf(addr,serviceInfo.getPort()))
         }
       }
       return map


### PR DESCRIPTION
Dart expects it to be this key in order to parse out the IP/port combinations.